### PR TITLE
Moved Run and Log to run param

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ migrations.jdbcUrl=${MY_JDBC_WRITE_URL_ENV}
 #### change [gradle.properties](gradle.properties) to setup migration directories
 ```properties
 # single migration directory configuration
-migrations.directory=my/migration/folder
+migrations.directory=my/single/module/src/main/resources/.migrations
 
 # multiple migration directory configuration
-migrations.directory[first]=my/first/migration/folder
-migrations.directory[second]=my/second/migration/folder
-migrations.directory[third]=my/third/migration/folder
+migrations.directory[first]=my/first/module/src/main/resources/.migrations
+migrations.directory[second]=my/second/module/src/main/resources/.migrations
+migrations.directory[third]=my/third/module/src/main/resources/.migrations
 ```

--- a/src/main/kotlin/io/tcds/orm/migrations/MigrationCreator.kt
+++ b/src/main/kotlin/io/tcds/orm/migrations/MigrationCreator.kt
@@ -4,13 +4,7 @@ import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class MigrationCreator(
-    private val writer: Writer,
-    private val properties: Map<String, *>,
-    private val log: (String) -> Unit,
-) {
-    private val directories: Map<String, String> = properties.directories()
-
+class MigrationCreator(private val writer: Writer) {
     class Writer {
         fun write(directory: String, name: String, content: String) {
             val dir = File(directory)
@@ -22,7 +16,9 @@ class MigrationCreator(
         }
     }
 
-    fun run() {
+    fun run(properties: Map<String, *>, log: (String) -> Unit) {
+        val directories: Map<String, String> = properties.directories()
+
         val name = properties["migration"]?.toString() ?: run {
             throw Exception("Missing migration name. Please run the command with `-P migration={name}` argument")
         }

--- a/src/main/kotlin/io/tcds/orm/migrations/MigrationRunner.kt
+++ b/src/main/kotlin/io/tcds/orm/migrations/MigrationRunner.kt
@@ -7,12 +7,8 @@ import io.tcds.orm.param.StringParam
 import java.io.File
 import java.time.LocalDateTime
 
-class MigrationRunner(
-    private val connection: Connection,
-    private val directories: Map<String, String>,
-    private val log: (String) -> Unit,
-) {
-    fun run() {
+class MigrationRunner(private val connection: Connection) {
+    fun run(directories: Map<String, String>, log: (String) -> Unit) {
         createMigrationTableIfNeeded()
 
         log("Running migrations...")

--- a/src/main/kotlin/io/tcds/orm/migrations/plugin/tasks/CreateMigrationTask.kt
+++ b/src/main/kotlin/io/tcds/orm/migrations/plugin/tasks/CreateMigrationTask.kt
@@ -6,7 +6,10 @@ import org.gradle.api.tasks.TaskAction
 
 abstract class CreateMigrationTask : DefaultTask() {
     @TaskAction
-    fun run() = MigrationCreator(MigrationCreator.Writer(), project.properties) { message ->
-        logger.lifecycle(message)
-    }.run()
+    fun run() {
+        MigrationCreator(MigrationCreator.Writer())
+            .run(project.properties) { message ->
+                logger.lifecycle(message)
+            }
+    }
 }

--- a/src/main/kotlin/io/tcds/orm/migrations/plugin/tasks/RunMigrationTask.kt
+++ b/src/main/kotlin/io/tcds/orm/migrations/plugin/tasks/RunMigrationTask.kt
@@ -26,10 +26,9 @@ abstract class RunMigrationTask : DefaultTask() {
         val jdbcConnection = ResilientConnection.reconnectable { DriverManager.getConnection(jdbcUrl) }
         val ormConnection = GenericConnection(jdbcConnection, jdbcConnection, null)
 
-        MigrationRunner(
-            connection = ormConnection,
-            directories = project.properties.directories(),
-            log = { message -> logger.lifecycle(message) },
-        ).run()
+        MigrationRunner(connection = ormConnection)
+            .run(project.properties.directories()) { message ->
+                logger.lifecycle(message)
+            }
     }
 }

--- a/src/test/kotlin/io/tcds/orm/migrations/MigrationCreatorTest.kt
+++ b/src/test/kotlin/io/tcds/orm/migrations/MigrationCreatorTest.kt
@@ -16,7 +16,7 @@ class MigrationCreatorTest {
     fun `given the properties when directory is missing then throw an exception`() = freezeClock {
         val props = emptyMap<String, Any>()
 
-        val exception = assertThrows<Exception> { MigrationCreator(writer, props, log) }
+        val exception = assertThrows<Exception> { MigrationCreator(writer).run(props, log) }
 
         assertEquals("Missing `migrations.directory` property", exception.message)
     }
@@ -24,9 +24,9 @@ class MigrationCreatorTest {
     @Test
     fun `given the properties when migration is missing then throw an exception`() = freezeClock {
         val props = mapOf<String, Any>("migrations.directory" to "migration/folder")
-        val creator = MigrationCreator(writer, props, log)
+        val creator = MigrationCreator(writer)
 
-        val exception = assertThrows<Exception> { creator.run() }
+        val exception = assertThrows<Exception> { creator.run(props, log) }
 
         assertEquals("Missing migration name. Please run the command with `-P migration={name}` argument", exception.message)
     }
@@ -37,9 +37,9 @@ class MigrationCreatorTest {
             "migrations.directory" to "migration/folder",
             "migration" to "FooBar",
         )
-        val creator = MigrationCreator(writer, props, log)
+        val creator = MigrationCreator(writer)
 
-        creator.run()
+        creator.run(props, log)
 
         verify(exactly = 1) {
             writer.write(
@@ -57,9 +57,9 @@ class MigrationCreatorTest {
             "migrations.directory[sales]" to "sales/migration/folder",
             "migration" to "FooBar",
         )
-        val creator = MigrationCreator(writer, props, log)
+        val creator = MigrationCreator(writer)
 
-        val exception = assertThrows<Exception> { creator.run() }
+        val exception = assertThrows<Exception> { creator.run(props, log) }
 
         assertEquals(
             "Missing migration directory. Please run the command with `-P module={module}` with one of `user,sales`",
@@ -75,9 +75,9 @@ class MigrationCreatorTest {
             "migration" to "FooBar",
             "module" to "sales",
         )
-        val creator = MigrationCreator(writer, props, log)
+        val creator = MigrationCreator(writer)
 
-        creator.run()
+        creator.run(props, log)
 
         verify(exactly = 1) {
             writer.write(


### PR DESCRIPTION
Having these properties injected in the constructor makes harded to have Runner configured in the container, there moving these params out of constructor fixes the issue